### PR TITLE
fix: lodash import not working in vite

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/Hovercard.svelte
+++ b/Hovercard.svelte
@@ -6,7 +6,7 @@
  LICENSE file.
 -->
 <script lang="ts">
-  import { debounce } from "lodash";
+  import { debounce } from "lodash-es";
 
   export let disabled: boolean = false;
   export let modalStyle: string | undefined = undefined;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "url": "https://github.com/radicle-dev/radicle-design-system.git"
   },
   "dependencies": {
+    "@types/lodash-es": "^4.17.6",
+    "lodash-es": "^4.17.21",
     "marked": "^4.0.16",
     "radicle-avatar": "github:radicle-dev/radicle-avatar",
     "sanitize-html": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,22 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@types/lodash-es@npm:^4.17.6":
+  version: 4.17.6
+  resolution: "@types/lodash-es@npm:4.17.6"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 9bd239dd525086e278821949ce12fbdd4f100a060fed9323fc7ad5661113e1641f28a7ebab617230ed3474680d8f4de705c1928b48252bb684be6ec9eed715db
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.14.182
+  resolution: "@types/lodash@npm:4.14.182"
+  checksum: 7dd137aa9dbabd632408bd37009d984655164fa1ecc3f2b6eb94afe35bf0a5852cbab6183148d883e9c73a958b7fec9a9bcf7c8e45d41195add6a18c34958209
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -188,6 +204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
+  languageName: node
+  linkType: hard
+
 "marked@npm:^4.0.16":
   version: 4.0.18
   resolution: "marked@npm:4.0.18"
@@ -269,6 +292,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "radicle-design-system@workspace:."
   dependencies:
+    "@types/lodash-es": ^4.17.6
+    lodash-es: ^4.17.21
     marked: ^4.0.16
     radicle-avatar: "github:radicle-dev/radicle-avatar"
     sanitize-html: ^2.7.0


### PR DESCRIPTION
The build here is breaking because lodash isn't an es-module: https://github.com/radicle-dev/workstreams-app/pull/158

This should fix that.