### PR TITLE
fix: relative file path for twemoji assets

### DIFF
--- a/Emoji.svelte
+++ b/Emoji.svelte
@@ -48,7 +48,7 @@
   {@html twemoji.parse(emoji, {
     className: `emoji ${size}`,
     base: $config.assetPathPrefix,
-    folder: "twemoji",
+    folder: "/twemoji",
     ext: ".svg",
   })}
 </div>


### PR DESCRIPTION
Currently, twemoji assets are being fetched from `twemoji` relative to the current URL. Which basically means that if you use the `Emoji` component while the URL is `/foo` it'll try to fetch emoji assets from `/foo/twemoji` instead of what you probably want — `/twemoji`.